### PR TITLE
feat: Publish docker image to GHCR

### DIFF
--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -1,0 +1,36 @@
+name: Docker - Publish Commit
+
+on:
+  push:
+    branches: "**"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@3.5.1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}


### PR DESCRIPTION
Use github actions to create and publish a docker image for yogbot.

We should probably try add a twistlock / etc step to this workflow at some point so that we have some vulnerability scanning.