### PR TITLE
Scan for vulnerabilities before publishing image

### DIFF
--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
-			- name: Build docker image
+      - name: Build docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .

--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -34,9 +34,9 @@ jobs:
           context: .
           tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
 
-			- uses: azure/container-scan@v0
-				with:
-					image-name: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
+      - uses: azure/container-scan@v0
+        with:
+          image-name: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc

--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -1,0 +1,36 @@
+name: Docker - Publish Commit
+
+on:
+  push:
+    branches: "**"
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@3.5.1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ github.token }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          push: true
+          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}

--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -38,7 +38,7 @@ jobs:
         with:
           image-name: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
 
-      - name: Build and push Docker image
+      - name: Push docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:
           context: .

--- a/.github/workflows/docker-commit.yaml
+++ b/.github/workflows/docker-commit.yaml
@@ -28,6 +28,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ github.token }}
 
+			- name: Build docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: .
+          tags: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
+
+			- uses: azure/container-scan@v0
+				with:
+					image-name: ${{ env.REGISTRY }}/${{ env.GITHUB_REPOSITORY_OWNER_PART_SLUG }}/${{ env.GITHUB_REPOSITORY_NAME_PART_SLUG }}:${{ env.GITHUB_REF_SLUG }}-${{ github.sha }}
+
       - name: Build and push Docker image
         uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.15.3 as compiler
+FROM alpine:3.16.0 as compiler
 
 RUN apk add --no-cache openjdk17 gradle
 
@@ -9,7 +9,7 @@ COPY src src
 RUN gradle --no-daemon bootJar
 
 
-FROM alpine:3.15.3
+FROM alpine:3.16.0
 
 RUN apk add --no-cache openjdk17-jre-headless
 

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
 
 plugins {
-    id 'org.springframework.boot' version '2.6.4'
+    id 'org.springframework.boot' version '2.7.0'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
     id 'org.jetbrains.kotlin.jvm' version '1.6.20-RC2'


### PR DESCRIPTION
Adds vulnerability scanning to the container publish workflow. This causes any builds with a HIGH or CRITICAL vulnerability to fail and not publish a docker image.

Additionally updates Spring Boot and Alpine as they had unresolved vulnerabilities.