### PR TITLE
Fixed ticket command replying with every message except the first

### DIFF
--- a/src/main/java/net/yogstation/yogbot/listeners/commands/TicketCommand.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/commands/TicketCommand.kt
@@ -116,7 +116,7 @@ class TicketCommand(
 				"${resultSet.getString("text")}\n"
 			if (builder.length + newline.length > Yogbot.MAX_MESSAGE_LENGTH - 10) {
 				builder.append("```")
-				if(hasSent)
+				if(!hasSent)
 					monos.add(DiscordUtil.reply(event, builder.toString()))
 				else
 					monos.add(DiscordUtil.send(event, builder.toString()))
@@ -131,7 +131,7 @@ class TicketCommand(
 			"Unable to find ticket $ticketId in round $roundId"
 		)
 		builder.append("```")
-		if(hasSent)
+		if(!hasSent)
 			monos.add(DiscordUtil.reply(event, builder.toString()))
 		else
 			monos.add(DiscordUtil.send(event, builder.toString()))


### PR DESCRIPTION
Command was supposed to reply with only the first message, but inverted conditional means it replied with every message but the first.