### PR TITLE
Adds more supported types to meme channel reactions

### DIFF
--- a/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
@@ -15,7 +15,11 @@ class MemesChannel(channelsConfig: DiscordChannelsConfig) : AbstractChannel(chan
 	override fun handle(event: MessageCreateEvent): Mono<*> {
 		val message = event.message
 		// If the message has an attachment, an embed, or a type in memetypes
-		if (message.attachments.size > 0 || message.embeds.size > 0 ||  memetypes.contains(message.content.split(".").last())) {
+		if (
+			message.attachments.size > 0 ||
+			message.embeds.size > 0 ||
+			memetypes.contains(message.content.split(".").last())
+			) {
 			// Java is strange with unicode in strings, this is thumbs up and down emoji
 			return message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4D"))
 				.and(message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4E")))

--- a/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
@@ -15,7 +15,7 @@ class MemesChannel(channelsConfig: DiscordChannelsConfig) : AbstractChannel(chan
 	override fun handle(event: MessageCreateEvent): Mono<*> {
 		val message = event.message
 		// If the message has an attachment, an embed, or a type in memetypes
-		if (message.attachments.size > 0 || message.embeds.size > 0 ||  memetypes.contains(message.content.split(".").last()))) {
+		if (message.attachments.size > 0 || message.embeds.size > 0 ||  memetypes.contains(message.content.split(".").last())) {
 			// Java is strange with unicode in strings, this is thumbs up and down emoji
 			return message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4D"))
 				.and(message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4E")))

--- a/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/channel/MemesChannel.kt
@@ -10,16 +10,12 @@ import reactor.core.publisher.Mono
 @Component
 class MemesChannel(channelsConfig: DiscordChannelsConfig) : AbstractChannel(channelsConfig) {
 	override val channel: Snowflake = Snowflake.of(channelsConfig.channelMemes)
+	val memetypes = setOf("mp4", "mov", "webm", "gif", "jpg", "jpeg", "png")
 
 	override fun handle(event: MessageCreateEvent): Mono<*> {
 		val message = event.message
-		// If the message has an attachment, an embed, or a link to mp4/gif it must be a meme
-		if (message.attachments.size > 0 ||
-			message.embeds.size > 0 ||
-			message.content.contains(".mp4") ||
-			message.content.contains(".gif") ||
-			message.content.contains(".mov")
-		) {
+		// If the message has an attachment, an embed, or a type in memetypes
+		if (message.attachments.size > 0 || message.embeds.size > 0 ||  memetypes.contains(message.content.split(".").last()))) {
 			// Java is strange with unicode in strings, this is thumbs up and down emoji
 			return message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4D"))
 				.and(message.addReaction(ReactionEmoji.unicode("\uD83D\uDC4E")))


### PR DESCRIPTION
Refactors the code a small bit to make adding new types easier

Adds jpg(+ jpeg), png and webm support

(a better way to do this IMO is to get the major mime type)