### PR TITLE
Added CVE-2016-1000027 to the allow list

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,3 @@
+general:
+  vulnerabilities:
+    - CVE-2016-1000027


### PR DESCRIPTION
Java de-serialization suffers from an RCE, and Spring used the java de-serialization for a feature. That feature was removed in a previous version, and we don't use java de-serialization.