### PR TITLE
Forces either logs or round number to be included in bug reports

### DIFF
--- a/src/main/java/net/yogstation/yogbot/listeners/channel/AbstractChannel.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/channel/AbstractChannel.kt
@@ -3,6 +3,8 @@ package net.yogstation.yogbot.listeners.channel
 import discord4j.common.util.Snowflake
 import discord4j.core.event.domain.message.MessageCreateEvent
 import net.yogstation.yogbot.config.DiscordChannelsConfig
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 
 /**
@@ -10,6 +12,8 @@ import reactor.core.publisher.Mono
  * matching the channel specified in the channel property.
  */
 abstract class AbstractChannel(protected val channelsConfig: DiscordChannelsConfig) {
+	protected val logger: Logger = LoggerFactory.getLogger(javaClass)
+
 	/**
 	 * The ID of the channel to get events for
 	 */

--- a/src/main/java/net/yogstation/yogbot/listeners/channel/RelayChannel.kt
+++ b/src/main/java/net/yogstation/yogbot/listeners/channel/RelayChannel.kt
@@ -4,7 +4,6 @@ import discord4j.core.event.domain.message.MessageCreateEvent
 import net.yogstation.yogbot.ByondConnector
 import net.yogstation.yogbot.config.DiscordChannelsConfig
 import org.apache.commons.text.StringEscapeUtils
-import org.slf4j.LoggerFactory
 import reactor.core.publisher.Mono
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
@@ -18,7 +17,6 @@ abstract class RelayChannel(channelsConfig: DiscordChannelsConfig, private val b
 	AbstractChannel(
 		channelsConfig
 	) {
-	private val logger = LoggerFactory.getLogger(javaClass)
 
 	/**
 	 * Setting this to true will take attached images and include them in the message sent to byond


### PR DESCRIPTION
Most repos require logs with bug reports, we can pull logs from round ID, so that suffices, but if a private server finds an issue, a zip of logs is sufficient. 